### PR TITLE
Removed celerybeat.pid from build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,4 @@ celery/**
 app/tests/mocks/**
 
 nginx/**
+celerybeat.pid


### PR DESCRIPTION
This fixes the ERROR: Pidfile (celerybeat.pid) already exists. error