### PR TITLE
Production: switch app container from runserver to gunicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # API CHANGELOG
 
+### 2026-06-10 — Production: switch to gunicorn (stop the dev-server restart loop)
+
+**Production stability**
+- `app` container in `docker-compose.prod.yml` no longer inherits the base compose's `python manage.py runserver 0.0.0.0:8000` (Django's **development** server). Overridden with `gunicorn app.wsgi:application --workers 3 --timeout 120 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -`. The dev server is single-threaded and not designed for HTTPS-proxied traffic, which was the source of the "accessing the development server over HTTPS" warnings and (very likely) the **1,337 restart count** observed on the prod app container. Gunicorn was already in `Pipfile.lock` (v21.2.0); the missing piece was just the compose `command:` override.
+- **Dockerfile**: explicitly install `gunicorn==23.0.0` (current stable) on top of the pipenv install, replacing the older pinned 21.2.0 from the lockfile.
+- **App service healthcheck**: added a minimal TCP healthcheck against `127.0.0.1:8000` so Docker only restarts when the worker is actually unreachable (rather than restarting on any process exit).
+
+**Database resilience**
+- Added `connect_timeout=10` to the default `DATABASES` `OPTIONS`. App and DB run on separate droplets in production; without a connect timeout, brief network blips would hang request workers for the OS default (~75-120s). Now they fail fast with a clean `OperationalError` so workers stay free for healthy traffic. Applies to all environments (10s is appropriate for local + prod alike).
+
 ### 2026-05-28 (later) — Resilient dataset downloads + richer error emails
 
 **Imports**

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app/
 COPY Pipfile Pipfile.lock /app/
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install pipenv==2023.10.24 setuptools && \
-    pipenv install --deploy --system
+    pipenv install --deploy --system && \
+    pip install --no-cache-dir gunicorn==23.0.0
 COPY . /app/
 EXPOSE 8000
 

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -133,7 +133,15 @@ DATABASES = {
         'HOST':  os.environ.get('DATABASE_HOST', 'localhost'),
         'USER': 'anhd',
         'PASSWORD':  os.environ.get('DATABASE_PASSWORD'),
-        'PORT':  os.environ.get('DATABASE_PORT', 5432)
+        'PORT':  os.environ.get('DATABASE_PORT', 5432),
+        # App and DB are on separate droplets in production; without an explicit
+        # connect_timeout, the OS default (~75-120s) lets brief network blips
+        # hang request workers rather than failing fast. 10s surfaces them as
+        # quick OperationalErrors so the request returns a 500 and gunicorn
+        # workers stay free for healthy traffic.
+        'OPTIONS': {
+            'connect_timeout': 10,
+        },
     }
 }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,22 @@ services:
       - .env
     environment:
       - TZ=America/New_York
+    # Production WSGI server. Overrides the base compose's `manage.py runserver`
+    # (Django's dev server) which was the source of the prod restart loop and
+    # the "accessing the development server over HTTPS" errors. 3 sync workers
+    # is a conservative default for this droplet alongside celery workers; tune
+    # later if needed. --timeout 120s accommodates the large district endpoints
+    # without letting hung requests pile up indefinitely.
+    command: gunicorn app.wsgi:application --workers 3 --timeout 120 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -
+    # TCP check on the gunicorn port — verifies a worker is listening. Avoids
+    # an HTTP probe (which could hit auth-required endpoints or large payloads)
+    # and avoids depending on curl being installed in the image.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket, sys; s=socket.socket(); s.settimeout(5); s.connect(('127.0.0.1', 8000)); s.close()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
   # https://www.digitalocean.com/community/tutorials/how-to-secure-a-containerized-node-js-application-with-nginx-let-s-encrypt-and-docker-compose
   flower:
     image: mher/flower


### PR DESCRIPTION
## Summary

Production has been running Django's **development server** (`python manage.py runserver`), not gunicorn — the source of the **1,337 restart count** observed on the `app` container, the recurring `"accessing the development server over HTTPS, but it only supports HTTP"` errors in logs, and the page-load crashes users have been reporting.

Verified directly from the running prod container:

```
docker inspect app → Cmd: [python manage.py runserver 0.0.0.0:8000]

ps -ef inside container:
  PID 1   python manage.py runserver 0.0.0.0:8000
  PID 14  /usr/local/bin/python manage.py runserver 0.0.0.0:8000

All log lines: [django.server:212] ← Django dev-server logger
```

Root cause: `docker-compose.prod.yml`'s `app` service didn't override the base `docker-compose.yml`'s `command: [python, manage.py, runserver, 0.0.0.0:8000]`. Gunicorn was already in `Pipfile.lock` (v21.2.0) — only the compose override was missing.

## Changes

- **`Dockerfile`** — explicitly install `gunicorn==23.0.0` (current stable, replacing the older 21.2.0 from the lockfile).
- **`docker-compose.prod.yml`** — override `app.command` to run gunicorn (3 sync workers, 120s timeout, access/error logs to stdout) + add a minimal TCP healthcheck so Docker only restarts on real worker failures.
- **`app/settings/base.py`** — add `connect_timeout=10` to the default `DATABASES` `OPTIONS` so cross-droplet network blips (app on `138.197.79.10`, DB on `104.131.161.212`) fail fast with a clean `OperationalError` instead of hanging gunicorn workers for the OS default (~75–120s).
- **`CHANGELOG.md`** — new dated entry.

## Verified locally

- `docker build` clean.
- `docker run --rm anhd_test gunicorn --version` → `gunicorn (version 23.0.0)`.
- `gunicorn --check-config app.wsgi:application` loads the WSGI app cleanly (exit 0, no errors).

## API compatibility

Zero. All changes are infrastructure-only (gunicorn command, DB connect timeout, healthcheck). No model/serializer/URL changes. Compatible with both the current live council-client (master) and staging.

## Deploy

Standard `sh deploy.sh` after merge — `git pull origin master && sh build.prod.sh` on the prod box, which runs `python manage.py migrate` on the way up. Expected window: ~1–3 min downtime during image rebuild + container recreate. The 1,337-restart pattern should stop once gunicorn is serving.