### PR TITLE
gunicorn: switch to gthread worker class (restore concurrency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # API CHANGELOG
 
+### 2026-06-10 (followup) — gunicorn: gthread worker class (restore concurrency)
+
+**Production stability (follow-up to the gunicorn switch)**
+- Switched gunicorn from the default **sync** worker (which only handles `--workers` concurrent requests = 3) to **gthread** with 4 threads per worker → `3 * 4 = 12` concurrent. This restores the concurrency Django's `runserver` had been providing implicitly (its `--threading` flag is on by default), which the initial gunicorn config silently dropped. Symptom was the portal loading screen hanging after deploy: the frontend fires 6+ endpoints on initial load; with 3 sync workers, requests queued behind the workers' 120s timeout and got SIGKILL'd before completing. gthread is built into gunicorn — no new dependency.
+- Bumped `--timeout` 120s → 180s for headroom on the largest cached district endpoints (`/councils/`, `/communities/`, `/stateassemblies/`, etc., each 2–4 MB).
+
 ### 2026-06-10 — Production: switch to gunicorn (stop the dev-server restart loop)
 
 **Production stability**

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,12 +8,17 @@ services:
     environment:
       - TZ=America/New_York
     # Production WSGI server. Overrides the base compose's `manage.py runserver`
-    # (Django's dev server) which was the source of the prod restart loop and
-    # the "accessing the development server over HTTPS" errors. 3 sync workers
-    # is a conservative default for this droplet alongside celery workers; tune
-    # later if needed. --timeout 120s accommodates the large district endpoints
-    # without letting hung requests pile up indefinitely.
-    command: gunicorn app.wsgi:application --workers 3 --timeout 120 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -
+    # (Django's dev server) which was the source of the original prod restart
+    # loop and the "accessing the development server over HTTPS" errors.
+    #
+    # Worker class: gthread (NOT sync). Django's runserver runs threaded by
+    # default, so handling N concurrent requests "just worked" — switching to
+    # sync workers cut concurrency to `--workers` (3 here), which queued the
+    # frontend's 6+ initial-load endpoints behind the workers, hit the timeout
+    # mid-response, and SIGKILL'd. gthread gives `workers * threads` concurrency
+    # (3 * 4 = 12) with no extra deps. 180s timeout accommodates the largest
+    # cached/uncached district endpoints without letting hung requests pile up.
+    command: gunicorn app.wsgi:application --worker-class gthread --workers 3 --threads 4 --timeout 180 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -
     # TCP check on the gunicorn port — verifies a worker is listening. Avoids
     # an HTTP probe (which could hit auth-required endpoints or large payloads)
     # and avoids depending on curl being installed in the image.


### PR DESCRIPTION
## Summary

Follow-up to PR #141. Live-applied on prod at 2026-06-10 14:05 ET via in-place `sed` + `force-recreate`; this PR makes it survive the next clean deploy.

## The bug PR #141 introduced

Django's `runserver` runs **threaded by default**. Switching to gunicorn with the default **sync** worker silently dropped concurrency to `--workers` = 3. The frontend fires 6+ endpoints on initial load — `/datasets/`, `/councils/`, `/communities/`, `/stateassemblies/`, `/statesenates/`, `/zipcodes/`. With only 3 sync workers, requests queued behind them, hit the 120s timeout, and got SIGKILL'd before completing. Symptom: stuck loading screen on portal.displacementalert.org.

```
[14:00:39] WORKER TIMEOUT (pid:142) → SIGKILL → boot pid:196
[14:01:04] WORKER TIMEOUT (pid:150) → SIGKILL → boot pid:210
... every ~25 seconds
```

CPU was idle (0.03%), memory fine (522 MB / 31 GB) — not OOM despite the misleading gunicorn message.

## Fix

- `--worker-class gthread` (built into gunicorn — no new deps)
- `--threads 4` → 3 workers × 4 threads = **12 concurrent requests**
- `--timeout 180` (up from 120) for headroom on the largest cached district endpoints

## Verified live on prod (after the manual patch)

| Endpoint | Time | Size |
|---|---|---|
| `/datasets/` | 0.12s | 9 KB |
| `/councils/` | 0.75s | 3.6 MB |
| `/communities/` | 0.69s | 2.5 MB |
| `/stateassemblies/` | 1.13s | 3.6 MB |
| `/statesenates/` | 0.81s | 3.5 MB |
| `/zipcodes/` | 0.72s | 2.8 MB |

Zero new WORKER TIMEOUT entries since restart.