### PR TITLE
Caching: fix CSV→JSON poisoning, size cap, session isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # API CHANGELOG
 
+### 2026-06-10 (cache fixes) — Cache key bug + size cap + session isolation
+
+**Caching (`datasets/helpers/cache_helpers.py`)**
+- **Root cause of multi-hundred-MB Redis entries**: `construct_cache_key` was popping `format` from the params, so `?format=csv&page=21960` and `?format=json&page=21960` shared the same cache slot. CSV responses (full table dumps, unpaginated) poisoned the JSON cache with values up to **350 MB per key**. We measured **14 bloated keys totaling ~1.5 GB** on prod (e.g. `/dobpermitissuednow/?page=6435` = 350 MB, `/dobissuedpermits/?page=21960` = 173 MB). Fix: stop stripping `format`; keep it in the cache key.
+- **CSV responses no longer cached at all** (`has_cachable_format` now JSON-only). CSV exports are bulk dumps, rarely re-hit, and don't fit Redis's per-key memory model — recomputing from the DB on each request is cheaper than blowing 350 MB of cache.
+- **Cache size cap**: refuse to `cache.set` any compressed value > **5 MB**. Defense in depth so a future bug can't reintroduce the poisoning. Emits a `WARNING` log with the cache_key when a value is refused, so the offending endpoint can be found.
+- **Halved Redis latency on cache hits**: was doing `cache_key in cache` (EXISTS) followed by `cache.get` (GET) = 2 round-trips per hit. Collapsed to a single `cache.get` + `is None` check.
+
+**Session isolation (`app/settings/base.py`, `app/tasks.py`)**
+- The `reset_cache` task was calling `cache.clear()`, which `django_redis` implements as `FLUSHDB` — wiping the **entire Redis DB**, including user sessions (`SESSION_ENGINE = django.contrib.sessions.backends.cache`). Every dataset cache reset effectively logged every user out.
+- Sessions moved to a new cache alias `sessions` with `KEY_PREFIX="SESS"` (`SESSION_CACHE_ALIAS = "sessions"`), and `reset_cache` switched from `cache.clear()` to `cache.delete_pattern("*")` which `django_redis` scopes to the default cache's prefix (`DAP:*`). Sessions are now untouched by cache resets.
+
+**Gunicorn (`docker-compose.prod.yml`)**
+- Added `--max-requests 1000 --max-requests-jitter 100` so each gthread worker recycles after ~1,000 requests, releasing accumulated memory (decompressed cache values, ORM caches). In-flight requests on the recycled worker complete normally; new worker boots immediately.
+
+**Deploy-time one-time cleanup needed**
+- The 14 poisoned cache entries identified above need to be flushed from prod Redis as part of this deploy (their keys are now logically dead because the cache-key format-stripping is gone, but the bytes still occupy Redis memory). Run `docker exec redis redis-cli --scan --pattern "DAP:*?page=*" | xargs -L 100 docker exec redis redis-cli DEL` (or equivalent) after the deploy.
+
 ### 2026-06-10 (followup) — gunicorn: gthread worker class (restore concurrency)
 
 **Production stability (follow-up to the gunicorn switch)**

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -154,7 +154,19 @@ CACHES = {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         },
         "KEY_PREFIX": "DAP"
-    }
+    },
+    # Sessions live under a separate alias so a dataset cache reset can't
+    # log every user out. Same Redis instance, different KEY_PREFIX, and
+    # reset_cache now uses delete_pattern("*") (scoped to DAP:*) instead of
+    # cache.clear() (which is FLUSHDB and wipes the whole Redis DB).
+    "sessions": {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': os.environ.get('REDIS_URL', 'redis://localhost:6378'),
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+        },
+        "KEY_PREFIX": "SESS"
+    },
 }
 
 
@@ -182,7 +194,7 @@ REST_FRAMEWORK = {
 WSGI_APPLICATION = 'app.wsgi.application'
 CACHE_TTL = 60 * 60 * 24  # cache for 24 hours
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
+SESSION_CACHE_ALIAS = "sessions"
 
 
 # Password validation

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -114,7 +114,12 @@ def clean_temp_directory(self):
 @app.task(bind=True, base=FaultTolerantTask, queue='celery', default_retry_delay=120, max_retries=2)
 def reset_cache(self, token):
     try:
-        cache.clear()
+        # Was cache.clear() — that runs FLUSHDB and wipes the WHOLE Redis DB,
+        # which on this stack includes user sessions (cache-backed). Switch to
+        # delete_pattern("*") which django_redis scopes to the default cache's
+        # KEY_PREFIX (DAP:*), so sessions (now on the "sessions" alias with
+        # KEY_PREFIX=SESS) survive a dataset cache reset.
+        cache.delete_pattern("*")
         create_async_cache_workers(token)
     except Exception as e:
         logger.error('Error during task: {}'.format(e))

--- a/datasets/helpers/cache_helpers.py
+++ b/datasets/helpers/cache_helpers.py
@@ -15,6 +15,12 @@ import logging
 
 logger = logging.getLogger('app')
 
+# Refuse to cache compressed response bodies bigger than this. Defense in depth
+# against a single huge response monopolizing Redis memory (we found a 350MB
+# entry at /dobpermitissuednow/?page=6435 from a CSV poisoning the JSON cache
+# before we separated the format from the cache key — see construct_cache_key).
+MAX_CACHE_VALUE_BYTES = 5 * 1024 * 1024  # 5 MB compressed
+
 
 def has_cachable_format(request):
     if settings.TESTING:
@@ -22,10 +28,10 @@ def has_cachable_format(request):
 
     params = request.query_params
 
-    formatted_request = 'format' in params.keys() and (
-        'json' in params['format'] or 'csv' in params['format'])
-
-    return formatted_request
+    # Only cache JSON. CSV responses are bulk exports (often the full table),
+    # rarely re-hit, and dwarf normal API payloads — caching them in Redis was
+    # the source of the multi-hundred-MB poisoned cache entries we cleaned up.
+    return 'format' in params.keys() and 'json' in params['format']
 
 
 def scrub_pagination(cached_value):
@@ -84,7 +90,11 @@ def is_authenticated(request):
 
 
 def construct_cache_key(request, params):
-    params.pop('format', None)
+    # NOTE: do NOT pop `format` here. Stripping it caused CSV responses
+    # (unpaginated full tables — easily 100+ MB) to share cache slots with
+    # paginated JSON responses (~100 KB), poisoning Redis with hundreds of MB
+    # per key. CSV is no longer cached at all (see has_cachable_format), but
+    # keep format in the key as defense in depth.
     params.pop('filename', None)
     cache_key = request.path + '?' + urllib.parse.urlencode(params)
     if is_authenticated(request):
@@ -104,30 +114,42 @@ def cache_request_path():
             if not is_authenticated(request) and 'q' in params and ('lispenden' in params['q'] or 'foreclosure' in params['q'] or 'ocahousingcourt' in params['q']):
                 return original_args[0].finalize_response(request, Response({'detail': 'Please login and request access to view results'}, status=status.HTTP_401_UNAUTHORIZED))
 
-            if cache_key in cache and has_cachable_format(request):
+            # Single Redis GET (was: EXISTS then GET → 2 round-trips per hit).
+            # `has_cachable_format` is cheap and gates the GET so we don't
+            # round-trip for uncacheable formats.
+            cached_value = cache.get(cache_key) if has_cachable_format(request) else None
+            if cached_value is not None:
                 logger.debug('Serving cache: {}'.format(cache_key))
-                cached_value = cache.get(cache_key)
                 cached_value = decompress_cache(cached_value)
                 cached_value = scrub_authenticated(cached_value, request)
                 return original_args[0].finalize_response(request, Response(cached_value))
             else:
                 response = function(*original_args, **original_kwargs)
 
-                # only cache good responses and json/csv formats
+                # only cache good JSON responses
                 if (response.status_code == 200) and has_cachable_format(request):
                     value_to_cache = response.data
                     value_to_cache = scrub_pagination(value_to_cache)
                     value_to_cache = compress_cache(value_to_cache)
-                    logger.debug('Caching: {}'.format(cache_key))
 
-                    cache.set(cache_key, value_to_cache,
-                              timeout=settings.CACHE_TTL)
-                    if '__authenticated' in cache_key:  # also cache the scrubbed response for unauthenticated requests
-                        cache_key = cache_key.replace('__authenticated', '')
-                        logger.debug(
-                            'Caching scrubbed varient: {}'.format(cache_key))
+                    if len(value_to_cache) > MAX_CACHE_VALUE_BYTES:
+                        # Don't bloat Redis with single huge responses; log so we
+                        # can identify endpoints that produce them.
+                        logger.warning(
+                            'Refusing to cache %s: compressed size %d bytes > %d limit',
+                            cache_key, len(value_to_cache), MAX_CACHE_VALUE_BYTES,
+                        )
+                    else:
+                        logger.debug('Caching: {}'.format(cache_key))
                         cache.set(cache_key, value_to_cache,
                                   timeout=settings.CACHE_TTL)
+                        if '__authenticated' in cache_key:  # also cache the scrubbed response for unauthenticated requests
+                            scrubbed_cache_key = cache_key.replace('__authenticated', '')
+                            logger.debug(
+                                'Caching scrubbed varient: {}'.format(scrubbed_cache_key))
+                            cache.set(scrubbed_cache_key, value_to_cache,
+                                      timeout=settings.CACHE_TTL)
+
                     logger.debug('Serving response: {}'.format(cache_key))
                     # TODO: remove pagination altogether
                     scrubbed_response = scrub_pagination(response.data)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,12 @@ services:
     # mid-response, and SIGKILL'd. gthread gives `workers * threads` concurrency
     # (3 * 4 = 12) with no extra deps. 180s timeout accommodates the largest
     # cached/uncached district endpoints without letting hung requests pile up.
-    command: gunicorn app.wsgi:application --worker-class gthread --workers 3 --threads 4 --timeout 180 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -
+    # --max-requests/--max-requests-jitter: recycle each worker after handling
+    # roughly N requests so accumulated per-worker memory (decompressed cache
+    # values, ORM caches) is released. Jitter prevents all workers recycling
+    # at the same time. Worker is gracefully shut + new one booted; in-flight
+    # requests on the recycled worker complete normally.
+    command: gunicorn app.wsgi:application --worker-class gthread --workers 3 --threads 4 --timeout 180 --max-requests 1000 --max-requests-jitter 100 --bind 0.0.0.0:8000 --access-logfile - --error-logfile -
     # TCP check on the gunicorn port — verifies a worker is listening. Avoids
     # an HTTP probe (which could hit auth-required endpoints or large payloads)
     # and avoids depending on curl being installed in the image.


### PR DESCRIPTION
## Summary

Fixes the root cause of the multi-hundred-MB Redis entries that have been thrashing gunicorn workers since today's deploy. Plus four supporting cleanups in the cache layer.

## Root cause: CSV/JSON shared cache keys

`construct_cache_key` was popping `format` from params:
```python
def construct_cache_key(request, params):
    params.pop("format", None)   # ← strips format before key construction
    params.pop("filename", None)
    cache_key = request.path + "?" + urllib.parse.urlencode(params)
```

So `?format=csv&page=21960` (unpaginated full table dump) and `?format=json&page=21960` (paginated, 100 records) shared the same cache slot. When a bot/scraper hit a CSV URL, the entire ~350MB table got cached under a key that JSON requests then read back.

## Measured on prod Redis right now

```
DAP:1:/dobpermitissuednow/?page=6435  → 350 MB
DAP:1:/dobissuedpermits/?page=21960   → 173 MB
DAP:1:/dobpermitissuednow/?page=*     → 10 entries × ~103 MB = ~1 GB
DAP:1:/housinglitigations/?page=1902  → 20 MB
DAP:1:/hpdcontacts/?page=7447         → 16 MB
─────────────────────────────────────────
14 keys, ~1.5 GB of poisoned cache out of 1.78 GB total Redis usage
```

This is what was tying up gunicorn workers — every hit decompressed 100s of MB into worker memory.

## Changes

### `datasets/helpers/cache_helpers.py`
- **Don't strip `format`** from cache key — CSV and JSON are now separate cache slots.
- **CSV no longer cacheable** (`has_cachable_format` now JSON-only). Bulk exports don't fit Redis's per-key memory model.
- **5MB compressed cache value cap** — defense in depth. Refused sets emit a `WARNING` log with the cache_key so the offending endpoint is findable.
- **Single Redis GET on cache hits** — was `cache_key in cache` (EXISTS) + `cache.get` (GET) = 2 round-trips per hit. Now one `cache.get` + `is None` check. Halves Redis latency on the hot path.

### `app/settings/base.py`
- New `sessions` cache alias with `KEY_PREFIX="SESS"`. Same Redis instance, different prefix.
- `SESSION_CACHE_ALIAS = "sessions"` — sessions no longer share the cache that gets reset on dataset updates.

### `app/tasks.py`
- `reset_cache`: `cache.clear()` (= FLUSHDB, wipes whole Redis incl. sessions) → `cache.delete_pattern("*")` which `django_redis` scopes to the default cache prefix (`DAP:*`). Sessions are untouched.

### `docker-compose.prod.yml`
- Add `--max-requests 1000 --max-requests-jitter 100` to the gunicorn command so workers recycle and release per-worker memory periodically.

## Deploy-time one-time cleanup needed

The 14 poisoned keys identified above still occupy Redis memory. After this deploy, run:
```bash
docker exec redis redis-cli --scan --pattern "DAP:*?page=*" \
  | xargs -L 100 docker exec redis redis-cli DEL
```
(or just `cache.delete_pattern("*")` via shell to fully reset the dataset cache, since the format-stripping bug means existing entries are logically dead anyway).

## Verified locally
- `manage.py check --deploy` clean (3 pre-existing security WARNINGS, unrelated).
- Image builds clean; new `sessions` cache alias loads.

## Safety
Cache layer changes are conservative: no API surface change, no model change, no migration. Worst case if something is off, cache hits start missing → views recompute (a temporary load uptick). Easy to revert.