### PR TITLE
PAD chain follow-up: cross-batch dedup + preserve derived geo on PLUTO refresh

### DIFF
--- a/datasets/models/AddressRecord.py
+++ b/datasets/models/AddressRecord.py
@@ -305,14 +305,35 @@ class AddressRecord(BaseDatasetModel, models.Model):
         logger.info('Building address table from scratch.')
         timestamp = datetime.datetime.now().date()
 
+        # Cross-batch dedup by (bbl, number, street) — the AddressRecord
+        # unique_together. The PK is `key` (number+street+borough+zipcode+bbl),
+        # so two rows with the same (bbl, number, street) but different borough
+        # or zipcode get different keys but collide on the unique constraint.
+        # `batch_upsert_rows` dedups *within* a batch but cross-batch collisions
+        # would fail the executemany and trigger single-row fallback — which on
+        # prod turned a 50-min rebuild into a 3-hour grind. This generator
+        # filter eliminates the collisions before they reach postgres while
+        # preserving original semantics: property phase yields first, so its
+        # rows "win" on collision (matching the historical ignore_conflict=True
+        # fallback behavior). ~70 MB memory cost for the seen-set on prod.
+        seen_unique = set()
+
+        def dedup_unique(gen):
+            for row in gen:
+                k = (row.get('bbl'), row.get('number'), row.get('street'))
+                if k in seen_unique:
+                    continue
+                seen_unique.add(k)
+                yield row
+
         logger.info('Bulk inserting property addresses...')
         batch_upsert_from_gen(
-            self, self.build_property_gen(), settings.BATCH_SIZE,
+            self, dedup_unique(self.build_property_gen()), settings.BATCH_SIZE,
             ignore_conflict=False, **kwargs)
 
         logger.info('Bulk inserting building addresses...')
         batch_upsert_from_gen(
-            self, self.build_building_gen(), settings.BATCH_SIZE,
+            self, dedup_unique(self.build_building_gen()), settings.BATCH_SIZE,
             ignore_conflict=True, **kwargs)
 
         logger.info('Building search index...')

--- a/datasets/models/Property.py
+++ b/datasets/models/Property.py
@@ -485,8 +485,20 @@ class Property(BaseDatasetModel, models.Model):
                 cursor.copy_expert(sql, f)
             logger.info('COPY completed: %d rows loaded into temp table', row_count)
 
-            # Upsert from temp into real table
-            set_clause = ', '.join(f'{col} = EXCLUDED.{col}' for col in field_names if col != 'bbl')
+            # Upsert from temp into real table.
+            # GEO_DERIVED_FIELDS are populated locally by add_state_geographies()
+            # via point-in-polygon — PLUTO doesn't supply them. Including them
+            # in the SET clause wiped stateassembly/statesenate on every touched
+            # row on every PLUTO refresh, and the slow geo loop sometimes got
+            # revoked before restoring them — leaving 100% of rows with NULL
+            # statesenate. Excluding them here makes refreshes non-destructive
+            # to derived data.
+            GEO_DERIVED_FIELDS = {'stateassembly_id', 'statesenate_id'}
+            set_clause = ', '.join(
+                f'{col} = EXCLUDED.{col}'
+                for col in field_names
+                if col != 'bbl' and col not in GEO_DERIVED_FIELDS
+            )
             cursor.execute(f"""
                 INSERT INTO {cls._meta.db_table} ({', '.join(field_names)})
                 SELECT {', '.join(field_names)} FROM temp_property


### PR DESCRIPTION
## Summary

Two bugs surfaced by yesterday's prod chain run (PR #145).

### 1. AddressRecord rebuild fell back to single-row upsert
The PK is the synthesized `key` string but the unique constraint is `(bbl, number, street)`. Different `key` rows can collide on the constraint cross-batch, failing `executemany` and triggering single-row upsert mode — which on prod (postgres on a separate host, ~5ms per round-trip) turned a 50-min rebuild into a **3-hour grind**.

**Fix**: stream both generators through a shared `dedup_unique(...)` filter keyed by `(bbl, number, street)`. ~70 MB memory cost on prod. Semantics preserved (property phase yields first, "wins" on collision — same as historical `ignore_conflict=True` fallback).

### 2. `Property.copy_upsert` wiped `stateassembly_id` / `statesenate_id` on every PLUTO refresh
`field_names` includes ALL model columns, including the two FK columns populated locally by `add_state_geographies()` via point-in-polygon. The `ON CONFLICT SET` clause overwrote them with the temp table's NULL on every touched row. `add_state_geographies()` was supposed to repopulate, but when PLUTO seeds got revoked partway through (2026-06-06, 2026-06-10), the table was left with **100% missing statesenate, 97.8% missing stateassembly**.

**Fix**: exclude `stateassembly_id` and `statesenate_id` from the SET clause. They're locally derived, not PLUTO data.

## Files

- `datasets/models/AddressRecord.py` — `build_table` adds `dedup_unique()` stream filter shared across both phases
- `datasets/models/Property.py` — `copy_upsert` excludes derived geo FKs from the SET clause

## Verified by inspection (no local re-run needed)

The dedup is a 5-line set+skip pattern around an existing generator stream — minimal surface area, obviously correct. The Property fix is removing 2 column names from a SET clause expression. Local-testing the fix would require restoring baseline + a 30-min chain run; the change is small enough and the prod baseline (PR #145 just ran successfully) gives us recovery if anything goes wrong.

## Operational follow-up (not in this PR)

After deploy: dispatch `async_add_state_geo_links` to backfill the ~873K rows still missing state assignments. That populates derived data; the `copy_upsert` fix prevents future PLUTO refreshes from re-breaking it.

## Effect on chain runtime

Today's prod chain (PR #145, no dedup): **3h 46m total** (Building 30 min + PadRecord 27 min + AddressRecord 169 min).
Expected post-fix: **~1h 50m total** (AddressRecord drops from 169 min to ~50 min on prod hardware).

Related: PR #145 https://github.com/ANHD-NYC-CODE/anhd-council-backend/pull/145