### PR TITLE
annotate_properties: surface failures (per-model try/except + email on outer failure)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -43,20 +43,31 @@ class Dataset(models.Model):
 
     @classmethod
     def annotate_properties_all(cls):
-        current_model_name = None  # Initialize variable to keep track of the current model name
-        try:
-            for model_name in settings.ANNOTATED_DATASETS:
-                current_model_name = model_name  # Update the current model name
-                if model_name == 'AcrisRealMaster':
-                    model_name = 'AcrisRealLegal'
-                dataset = cls.objects.get(model_name=model_name)
+        # Run every dataset's annotate_properties — but if any of them fail,
+        # keep going and collect the failures, then raise an aggregate at the
+        # end so the outer celery task sees FAILURE (and handle_task_error
+        # fires an email). Previously the try/except wrapped the ENTIRE loop,
+        # so a single failure aborted the remaining datasets AND silently
+        # swallowed the exception (task showed SUCCESS in TaskResult even
+        # though most annotations didn't run).
+        failures = []
+        for model_name in settings.ANNOTATED_DATASETS:
+            try:
+                effective = 'AcrisRealLegal' if model_name == 'AcrisRealMaster' else model_name
+                dataset = cls.objects.get(model_name=effective)
                 dataset.model().annotate_properties()
-        except Exception as e:
-            if current_model_name:
+            except Exception as e:
                 logger.error(
-                    f'Error during task for model_name "{current_model_name}": {e}')
-            else:
-                logger.error(f'Error during task: {e}')
+                    'annotate_properties failed for %s: %s', model_name, e,
+                    exc_info=True,
+                )
+                failures.append((model_name, e))
+
+        if failures:
+            names = ', '.join(name for name, _ in failures)
+            raise Exception(
+                'annotate_properties failed for {} dataset(s): {}'.format(len(failures), names)
+            )
 
     def model(self):
         return getattr(ds, self.model_name)

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -148,7 +148,15 @@ def async_create_update(self, dataset_id, file_id=None):
 
 @app.task(bind=True, base=FaultTolerantTask, queue='update', acks_late=True, max_retries=1)
 def async_annotate_properties_with_all_datasets(self):
-    c.Dataset.annotate_properties_all()
+    # Wrap so handle_task_error fires on failure — that path emails the
+    # admins via async_send_general_task_error_mail. Without this wrapper the
+    # task can fail silently (celery marks TaskResult as FAILURE but no email
+    # goes out, so nobody notices that nightly annotations stopped working).
+    try:
+        c.Dataset.annotate_properties_all()
+    except Exception as e:
+        handle_task_error(e)
+        raise e
 
 
 @app.task(bind=True, base=FaultTolerantTask, queue='update', acks_late=True, max_retries=1)


### PR DESCRIPTION
Nightly `annotate properties all` cron (4 AM EST) had two silent-failure issues:

1. `Dataset.annotate_properties_all` wrapped the entire for-loop in try/except and never re-raised → first failing model aborted the rest AND the outer task returned SUCCESS.
2. `async_annotate_properties_with_all_datasets` had no `handle_task_error` wrapper → even if it did fail, no email was sent.

**After this:** failures fire `async_send_general_task_error_mail` so admins get notified, and one bad model annotation doesn't skip the others.

Matches the error-handling pattern other tasks (`async_seed_file`, `async_download_and_update`, etc.) already use.

Related: card https://trello.com/c/TaQgzvAA (nightly annotation N+1 audit)